### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 _A server with a little magic_.
 
 [![Build Status](https://travis-ci.org/supernintendo/moongate.svg?branch=master)](https://travis-ci.org/supernintendo/moongate)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/supernintendo/moongate.svg)](https://beta.hexfaktor.org/github/supernintendo/moongate)
 [![Inline docs](http://inch-ci.org/github/supernintendo/moongate.svg?branch=master)](http://inch-ci.org/github/supernintendo/moongate)
 [![Gitter](https://badges.gitter.im/supernintendo/moongate.svg)](https://gitter.im/supernintendo/moongate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/supernintendo/moongate.svg)](https://beta.hexfaktor.org/github/supernintendo/moongate) [![Inline docs](http://inch-ci.org/github/supernintendo/moongate.svg?branch=master)](http://inch-ci.org/github/supernintendo/moongate)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!